### PR TITLE
Let TextPage fallback to `[modid]:text/manual.txt` when given resource is absent

### DIFF
--- a/src/main/java/mcjty/lib/gui/widgets/TextPage.java
+++ b/src/main/java/mcjty/lib/gui/widgets/TextPage.java
@@ -104,7 +104,12 @@ public class TextPage extends AbstractWidget<TextPage> {
         TextPage.Page page = new TextPage.Page();
         try {
             IResourceManager resourceManager = mc.getResourceManager();
-            IResource iresource = resourceManager.getResource(manualResource);
+            IResource iresource;
+            try {
+                iresource = resourceManager.getResource(manualResource);
+            } catch (Exception e) {
+                iresource = resourceManager.getResource(new ResourceLocation(manualResource.getResourceDomain(), "text/manual.txt"));
+            }
             InputStream inputstream = iresource.getInputStream();
             BufferedReader br = new BufferedReader(new InputStreamReader(inputstream, "UTF-8"));
             String line = br.readLine();


### PR DESCRIPTION
This pull request is complementary to McJty/RFTools#1084. More information can be found there.