### PR TITLE
Make #31 more generic

### DIFF
--- a/src/main/java/mcjty/lib/gui/widgets/TextPage.java
+++ b/src/main/java/mcjty/lib/gui/widgets/TextPage.java
@@ -108,7 +108,8 @@ public class TextPage extends AbstractWidget<TextPage> {
             try {
                 iresource = resourceManager.getResource(manualResource);
             } catch (Exception e) {
-                iresource = resourceManager.getResource(new ResourceLocation(manualResource.getResourceDomain(), "text/manual.txt"));
+                String fallBackPath = manualResource.getResourcePath().replaceAll("-([a-z\\-]{2,6})_?([a-z]{0,3})", "");
+                iresource = resourceManager.getResource(new ResourceLocation(manualResource.getResourceDomain(), fallBackPath));
             }
             InputStream inputstream = iresource.getInputStream();
             BufferedReader br = new BufferedReader(new InputStreamReader(inputstream, "UTF-8"));


### PR DESCRIPTION
Now use regex to truncate the language code in resource path.
The regex used here is `-([a-z\\-]{2,6})_?([a-z]{0,3})`, which can cover [any language that is supported by vanilla Minecraft](http://minecraft.gamepedia.com/Language#Available_languages).
This is required for situations like McJty/RFToolsDimensions#91 where the manual is named something else (e.g. `manual_dim.txt` for RFToolsDimension).
And I apologize for bothering.