### PR TITLE
Update OC integration to the latest OC for 1.12.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ minecraft {
 
 dependencies {
     deobfCompile "mezz.jei:jei_1.12:4.7.0.67"
-    compile "li.cil.oc:OpenComputers:MC1.10.2-1.6.+:api"
+    compile "li.cil.oc:OpenComputers:MC1.12.1-1.7.+:api"
     deobfCompile "cofh:RedstoneFlux:1.12-2.0.0.1:universal"
     deobfCompile "mcp.mobius.waila:Hwyla:1.8.18-B32_1.12:api"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.11-5"

--- a/src/main/java/mcjty/lib/integration/computers/AbstractOCDriver.java
+++ b/src/main/java/mcjty/lib/integration/computers/AbstractOCDriver.java
@@ -3,12 +3,13 @@ package mcjty.lib.integration.computers;
 import li.cil.oc.api.Network;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.network.Visibility;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import li.cil.oc.api.prefab.DriverSidedTileEntity;
-import li.cil.oc.api.prefab.ManagedEnvironment;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
 
 public abstract class AbstractOCDriver extends DriverSidedTileEntity {
     String componentName;
@@ -19,7 +20,7 @@ public abstract class AbstractOCDriver extends DriverSidedTileEntity {
         this.clazz = clazz;
     }
 
-    public abstract static class InternalManagedEnvironment<T> extends ManagedEnvironment implements NamedBlock {
+    public abstract static class InternalManagedEnvironment<T> extends AbstractManagedEnvironment implements NamedBlock {
         protected T tile;
         private String componentName;
 
@@ -51,7 +52,7 @@ public abstract class AbstractOCDriver extends DriverSidedTileEntity {
     }
 
     @Override
-    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+    public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tile = world.getTileEntity(pos);
         if (clazz.isInstance(tile)) {
             return this.createEnvironment(world, pos, side, tile);
@@ -59,5 +60,5 @@ public abstract class AbstractOCDriver extends DriverSidedTileEntity {
         return null;
     }
 
-    public abstract ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile);
+    public abstract AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile);
 }


### PR DESCRIPTION
There's been a small API change renaming ManagedEnvironment to
AbstractManagedEnvironment. This is a prerequisite to enabling
OC integration again in RFTools.