### PR TITLE
Fix multitooltip crashes on 1.11 as well.

### DIFF
--- a/src/main/java/mcjty/lib/container/GenericGuiContainer.java
+++ b/src/main/java/mcjty/lib/container/GenericGuiContainer.java
@@ -133,7 +133,7 @@ public abstract class GenericGuiContainer<T extends GenericTileEntity> extends G
             int linesWithItemStacks = 0;
             for (String s : textLines) {
                 int j;
-                if (s.contains("@") && !items.isEmpty()) {
+                if (s != null && items != null && s.contains("@") && !items.isEmpty()) {
                     linesWithItemStacks++;
                     List list = parseString(s, items);
                     j = 0;
@@ -187,7 +187,7 @@ public abstract class GenericGuiContainer<T extends GenericTileEntity> extends G
 
             for (int k1 = 0; k1 < textLines.size(); ++k1) {
                 String s1 = textLines.get(k1);
-                if (s1.contains("@") && !items.isEmpty()) {
+                if (s != null && items != null && s1.contains("@") && !items.isEmpty()) {
                     List list = parseString(s1, items);
                     int curx = xx;
                     for (Object o : list) {


### PR DESCRIPTION
Re: #46 -- I don't have 1.11 set up for testing right now, but it's just
a couple null checks in the right places. This fixes it on 1.12 for
sure, so I assume the same will work for 1.11 as well.