### PR TITLE
Right-click to reverse through choices

### DIFF
--- a/src/main/java/mcjty/lib/gui/widgets/ChoiceLabel.java
+++ b/src/main/java/mcjty/lib/gui/widgets/ChoiceLabel.java
@@ -90,7 +90,7 @@ public class ChoiceLabel extends Label<ChoiceLabel> {
                 return null;
             }
             int index = choiceList.indexOf(currentChoice);
-            if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
+            if (button == 1 || Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
                 index--;
                 if (index < 0) {
                     index = choiceList.size()-1;

--- a/src/main/java/mcjty/lib/gui/widgets/ColorChoiceLabel.java
+++ b/src/main/java/mcjty/lib/gui/widgets/ColorChoiceLabel.java
@@ -81,7 +81,7 @@ public class ColorChoiceLabel extends Label<ColorChoiceLabel> {
     public Widget mouseClick(Window window, int x, int y, int button) {
         if (isEnabledAndVisible()) {
             int index = colorList.indexOf(currentColor);
-            if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
+            if (button == 1 || Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
                 index--;
                 if (index < 0) {
                     index = colorList.size()-1;

--- a/src/main/java/mcjty/lib/gui/widgets/ImageChoiceLabel.java
+++ b/src/main/java/mcjty/lib/gui/widgets/ImageChoiceLabel.java
@@ -80,7 +80,7 @@ public class ImageChoiceLabel extends ImageLabel<ImageChoiceLabel> {
     @Override
     public Widget mouseClick(Window window, int x, int y, int button) {
         if (isEnabledAndVisible()) {
-            if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
+            if (button == 1 || Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
                 currentChoice--;
                 if (currentChoice < 0) {
                     currentChoice = choiceList.size() - 1;


### PR DESCRIPTION
It's more intuitive to right-click than to shift-click to reverse through
choices, so give users the option to do that instead.