### PR TITLE
Add DamageMetadataItemBlock

### DIFF
--- a/src/main/java/mcjty/lib/container/DamageMetadataItemBlock.java
+++ b/src/main/java/mcjty/lib/container/DamageMetadataItemBlock.java
@@ -1,0 +1,18 @@
+package mcjty.lib.container;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemBlock;
+
+public class DamageMetadataItemBlock extends ItemBlock {
+
+    public DamageMetadataItemBlock(Block block) {
+        super(block);
+        setHasSubtypes(true);
+    }
+
+    @Override
+    public int getMetadata(int damage) {
+        return damage;
+    }
+
+}


### PR DESCRIPTION
Lots of places (in RFTools and XNet, and probably others) use the exact same
subclassing of ItemBlock. Put it here to avoid repeating it every time.