### PR TITLE
Remove old fix for teleporting out of The End

### DIFF
--- a/src/main/java/mcjty/lib/varia/TeleportationTools.java
+++ b/src/main/java/mcjty/lib/varia/TeleportationTools.java
@@ -61,12 +61,6 @@ public class TeleportationTools {
 
         worldServer.getMinecraftServer().getPlayerList().transferPlayerToDimension(entityPlayerMP, dimension, new McJtyLibTeleporter(worldServer, x, y, z));
         player.setPositionAndUpdate(x, y, z);
-        if (oldDimension == 1) {
-            // For some reason teleporting out of the end does weird things.
-            player.setPositionAndUpdate(x, y, z);
-            worldServer.spawnEntity(player);
-            worldServer.updateEntityWithOptionalForce(player, false);
-        }
     }
 
     private static void facePosition(Entity entity, double newX, double newY, double newZ, BlockPos dest) {


### PR DESCRIPTION
Removing the old fix for teleporting out of The End seems to solve
issues McJtyMods/RFTools#1747 and McJtyMods/RFTools#1786 while still allowing teleportation. Tested in Enigmatica 2 version 1.42 using integrated server.