### PR TITLE
Partial update to Minecraft 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     repositories {
         maven { url = 'https://maven.minecraftforge.net/' }
         maven { url 'https://plugins.gradle.org/m2/' }
-        jcenter()
         mavenCentral()
     }
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ projectId=233105
 github_project=McJtyMods/McJtyLib
 
 minecraft_version=1.17.1
-forge_version=37.0.13
+forge_version=37.0.126
 
 jei_version=1.16.4:7.6.1.65
 patchouli_version=1.16-42

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ projectId=233105
 github_project=McJtyMods/McJtyLib
 
 minecraft_version=1.17.1
-forge_version=37.0.126
+forge_version=37.1.0
 
 jei_version=1.16.4:7.6.1.65
 patchouli_version=1.16-42

--- a/src/main/java/mcjty/lib/api/container/CapabilityContainerProvider.java
+++ b/src/main/java/mcjty/lib/api/container/CapabilityContainerProvider.java
@@ -2,16 +2,16 @@ package mcjty.lib.api.container;
 
 import net.minecraft.world.MenuProvider;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityContainerProvider {
 
-    @CapabilityInject(MenuProvider.class)
-    public static Capability<MenuProvider> CONTAINER_PROVIDER_CAPABILITY = null;
+    public static Capability<MenuProvider> CONTAINER_PROVIDER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register() {
-        CapabilityManager.INSTANCE.register(MenuProvider.class);
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(MenuProvider.class);
     }
 
 }

--- a/src/main/java/mcjty/lib/api/information/CapabilityPowerInformation.java
+++ b/src/main/java/mcjty/lib/api/information/CapabilityPowerInformation.java
@@ -1,16 +1,16 @@
 package mcjty.lib.api.information;
 
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityPowerInformation {
 
-    @CapabilityInject(IPowerInformation.class)
-    public static Capability<IPowerInformation> POWER_INFORMATION_CAPABILITY = null;
+    public static Capability<IPowerInformation> POWER_INFORMATION_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register() {
-        CapabilityManager.INSTANCE.register(IPowerInformation.class);
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(IPowerInformation.class);
     }
 
 }

--- a/src/main/java/mcjty/lib/api/infusable/CapabilityInfusable.java
+++ b/src/main/java/mcjty/lib/api/infusable/CapabilityInfusable.java
@@ -1,16 +1,16 @@
 package mcjty.lib.api.infusable;
 
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityInfusable {
 
-    @CapabilityInject(IInfusable.class)
-    public static Capability<IInfusable> INFUSABLE_CAPABILITY = null;
+    public static Capability<IInfusable> INFUSABLE_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register() {
-        CapabilityManager.INSTANCE.register(IInfusable.class);
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(IInfusable.class);
     }
 
 }

--- a/src/main/java/mcjty/lib/api/module/CapabilityModuleSupport.java
+++ b/src/main/java/mcjty/lib/api/module/CapabilityModuleSupport.java
@@ -1,16 +1,16 @@
 package mcjty.lib.api.module;
 
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 
 public class CapabilityModuleSupport {
 
-    @CapabilityInject(IModuleSupport.class)
-    public static Capability<IModuleSupport> MODULE_CAPABILITY = null;
+    public static Capability<IModuleSupport> MODULE_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public static void register() {
-        CapabilityManager.INSTANCE.register(IModuleSupport.class);
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(IModuleSupport.class);
     }
 
 }

--- a/src/main/java/mcjty/lib/client/RenderHelper.java
+++ b/src/main/java/mcjty/lib/client/RenderHelper.java
@@ -339,18 +339,17 @@ public class RenderHelper {
                 buffer.endBatch();
             }
 
-            if (stack.getItem().showDurabilityBar(stack)) {
+            if (stack.getItem().isBarVisible(stack)) {
                 RenderSystem.disableDepthTest();
                 RenderSystem.disableTexture();
 //                RenderSystem.disableAlphaTest();  // @todo 1.17
                 RenderSystem.disableBlend();
                 Tesselator tessellator = Tesselator.getInstance();
                 BufferBuilder bufferbuilder = tessellator.getBuilder();
-                double health = stack.getItem().getDurabilityForDisplay(stack);
-                int i = Math.round(13.0F - (float)health * 13.0F);
-                int j = stack.getItem().getRGBDurabilityForDisplay(stack);
+                int barWidth = stack.getItem().getBarWidth(stack);
+                int j = stack.getItem().getBarColor(stack);
                 draw(bufferbuilder, xPosition + 2, yPosition + 13, 13, 2, 0, 0, 0, 255);
-                draw(bufferbuilder, xPosition + 2, yPosition + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
+                draw(bufferbuilder, xPosition + 2, yPosition + 13, barWidth, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
                 RenderSystem.enableBlend();
 //                RenderSystem.enableAlphaTest();   // @todo 1.17
                 RenderSystem.enableTexture();
@@ -410,11 +409,11 @@ public class RenderHelper {
                 RenderSystem.enableBlend();
             }
 
-            if (stack.getItem().showDurabilityBar(stack)) {
-                double health = stack.getItem().getDurabilityForDisplay(stack);
-                int j = (int) Math.round(13.0D - health * 13.0D);
-                int i = (int) Math.round(255.0D - health * 255.0D);
-                // @todo 1.17 port rendering
+//            if (stack.getItem().showDurabilityBar(stack)) {
+//                double health = stack.getItem().getDurabilityForDisplay(stack);
+//                int j = (int) Math.round(13.0D - health * 13.0D);
+//                int i = (int) Math.round(255.0D - health * 255.0D);
+//                // @todo 1.17 port rendering
 //                RenderSystem.disableLighting();
 //                RenderSystem.disableDepthTest();
 //                RenderSystem.disableTexture();
@@ -430,7 +429,7 @@ public class RenderHelper {
 //                RenderSystem.enableTexture();
 //                RenderSystem.enableLighting();
 //                RenderSystem.enableDepthTest();
-            }
+//            }
 
             LocalPlayer PlayerEntitysp = Minecraft.getInstance().player;
             float f = PlayerEntitysp == null ? 0.0F : PlayerEntitysp.getCooldowns().getCooldownPercent(stack.getItem(), Minecraft.getInstance().getFrameTime());

--- a/src/main/java/mcjty/lib/font/TrueTypeFont.java
+++ b/src/main/java/mcjty/lib/font/TrueTypeFont.java
@@ -237,7 +237,7 @@ public class TrueTypeFont {
                 if (i < 256) { // standard characters
                     charArray[i] = newIntObject;
                 } else { // custom characters
-                    customChars.put(new Character(ch), newIntObject);
+                    customChars.put(Character.valueOf(ch), newIntObject);
                 }
 
                 fontImage = null;
@@ -294,7 +294,7 @@ public class TrueTypeFont {
             if (currentChar < 256) {
                 floatObject = charArray[currentChar];
             } else {
-                floatObject = customChars.get(new Character((char) currentChar));
+                floatObject = customChars.get(Character.valueOf((char) currentChar));
             }
 
             if (floatObject != null) {
@@ -458,7 +458,7 @@ public class TrueTypeFont {
             if (charCurrent < 256) {
                 floatObject = charArray[charCurrent];
             } else {
-                floatObject = customChars.get(new Character((char) charCurrent));
+                floatObject = customChars.get(Character.valueOf((char) charCurrent));
             }
 
             if (floatObject != null) {
@@ -473,7 +473,7 @@ public class TrueTypeFont {
                             if (charCurrent < 256) {
                                 floatObject = charArray[charCurrent];
                             } else {
-                                floatObject = customChars.get(new Character((char) charCurrent));
+                                floatObject = customChars.get(Character.valueOf((char) charCurrent));
                             }
                             totalwidth += floatObject.width - correctL;
                         }

--- a/src/main/java/mcjty/lib/multipart/MultipartItemBlock.java
+++ b/src/main/java/mcjty/lib/multipart/MultipartItemBlock.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.util.Constants.BlockFlags;
 
 import javax.annotation.Nonnull;
 
@@ -158,7 +157,7 @@ public class MultipartItemBlock extends BlockItem {
         }
 
         BlockState multiState = Registration.MULTIPART_BLOCK.defaultBlockState();
-        if (!world.setBlock(pos, multiState, BlockFlags.BLOCK_UPDATE + BlockFlags.NOTIFY_NEIGHBORS + BlockFlags.UPDATE_NEIGHBORS)) {
+        if (!world.setBlock(pos, multiState, Block.UPDATE_CLIENTS + Block.UPDATE_NEIGHBORS + Block.UPDATE_KNOWN_SHAPE)) {
             return false;
         }
 

--- a/src/main/java/mcjty/lib/multipart/MultipartTE.java
+++ b/src/main/java/mcjty/lib/multipart/MultipartTE.java
@@ -18,7 +18,6 @@ import net.minecraftforge.client.model.ModelDataManager;
 import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.data.ModelDataMap;
 import net.minecraftforge.client.model.data.ModelProperty;
-import net.minecraftforge.common.util.Constants;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -144,7 +143,7 @@ public class MultipartTE extends BlockEntity {
         load(packet.getTag());
         if (level.isClientSide && version != oldVersion) {
             ModelDataManager.requestModelDataRefresh(this);
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Constants.BlockFlags.BLOCK_UPDATE + Constants.BlockFlags.NOTIFY_NEIGHBORS);
+            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_CLIENTS + Block.UPDATE_NEIGHBORS);
         }
     }
 

--- a/src/main/java/mcjty/lib/multipart/MultipartTE.java
+++ b/src/main/java/mcjty/lib/multipart/MultipartTE.java
@@ -5,6 +5,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.level.Level;
@@ -190,7 +191,7 @@ public class MultipartTE extends BlockEntity {
 
         Map<PartSlot, MultipartTE.Part> newparts = new HashMap<>();
         version = compound.getInt("version");
-        ListTag list = compound.getList("parts", Constants.NBT.TAG_COMPOUND);
+        ListTag list = compound.getList("parts", Tag.TAG_COMPOUND);
         for (int i = 0 ; i < list.size() ; i++) {
             CompoundTag tag = list.getCompound(i);
 

--- a/src/main/java/mcjty/lib/preferences/PreferencesProperties.java
+++ b/src/main/java/mcjty/lib/preferences/PreferencesProperties.java
@@ -7,6 +7,7 @@ import mcjty.lib.network.PacketSendPreferencesToClient;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.fmllegacy.network.NetworkDirection;
 
 import javax.annotation.Nonnull;
@@ -114,7 +115,7 @@ public class PreferencesProperties {
         return buffY;
     }
 
-    public static void register() {
-        CapabilityManager.INSTANCE.register(PreferencesProperties.class);
+    public static void register(RegisterCapabilitiesEvent event) {
+        event.register(PreferencesProperties.class);
     }
 }

--- a/src/main/java/mcjty/lib/setup/ModSetup.java
+++ b/src/main/java/mcjty/lib/setup/ModSetup.java
@@ -25,7 +25,9 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -42,21 +44,20 @@ public class ModSetup extends DefaultModSetup {
 
     public static boolean patchouli = false;
 
-    @CapabilityInject(PreferencesProperties.class)
-    public static Capability<PreferencesProperties> PREFERENCES_CAPABILITY;
+    public static Capability<PreferencesProperties> PREFERENCES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    private static void registerCapabilities(){
-        CapabilityContainerProvider.register();
-        CapabilityInfusable.register();
-        CapabilityPowerInformation.register();
-        CapabilityModuleSupport.register();
-        PreferencesProperties.register();
+    @SubscribeEvent
+    public static void registerCapabilities(RegisterCapabilitiesEvent event){
+        CapabilityContainerProvider.register(event);
+        CapabilityInfusable.register(event);
+        CapabilityPowerInformation.register(event);
+        CapabilityModuleSupport.register(event);
+        PreferencesProperties.register(event);
     }
 
     @Override
     public void init(FMLCommonSetupEvent e) {
         super.init(e);
-        registerCapabilities();
         McJtyLib.networkHandler = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, MODID), () -> "1.0", s -> true, s -> true);
         PacketHandler.registerMessages(McJtyLib.networkHandler);
         MinecraftForge.EVENT_BUS.register(new EventHandler());

--- a/src/main/java/mcjty/lib/tileentity/GenericTileEntity.java
+++ b/src/main/java/mcjty/lib/tileentity/GenericTileEntity.java
@@ -29,13 +29,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fmllegacy.network.simple.SimpleChannel;
@@ -76,7 +76,7 @@ public class GenericTileEntity extends BlockEntity implements ICommandHandler, I
         setChanged();
         if (getLevel() != null) {
             BlockState state = getLevel().getBlockState(getBlockPos());
-            getLevel().sendBlockUpdated(getBlockPos(), state, state, Constants.BlockFlags.BLOCK_UPDATE + Constants.BlockFlags.NOTIFY_NEIGHBORS);
+            getLevel().sendBlockUpdated(getBlockPos(), state, state, Block.UPDATE_CLIENTS + Block.UPDATE_NEIGHBORS);
         }
     }
 

--- a/src/main/java/mcjty/lib/tileentity/GenericTileEntity.java
+++ b/src/main/java/mcjty/lib/tileentity/GenericTileEntity.java
@@ -19,6 +19,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.InteractionHand;
@@ -274,7 +275,7 @@ public class GenericTileEntity extends BlockEntity implements ICommandHandler, I
         getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
                 .filter(h -> h instanceof INBTSerializable)
                 .map(h -> (INBTSerializable) h)
-                .ifPresent(h -> h.deserializeNBT(tagCompound.getList("Items", Constants.NBT.TAG_COMPOUND)));
+                .ifPresent(h -> h.deserializeNBT(tagCompound.getList("Items", Tag.TAG_COMPOUND)));
     }
 
     protected void readEnergyCap(CompoundTag tagCompound) {

--- a/src/main/java/mcjty/lib/varia/NBTTools.java
+++ b/src/main/java/mcjty/lib/varia/NBTTools.java
@@ -106,7 +106,7 @@ public class NBTTools {
 
     @Nonnull
     public static Stream<Tag> getListStream(CompoundTag compound, String tag) {
-        ListTag list = compound.getList("Items", Constants.NBT.TAG_COMPOUND);
+        ListTag list = compound.getList("Items", Tag.TAG_COMPOUND);
         return StreamSupport.stream(list.spliterator(), false);
     }
 }


### PR DESCRIPTION
- Partially updates class names and constants to their new names.
- Updates method of capability registration.

Notable remaining items:
- The removal of net.minecraftforge.common.ToolType and Block.getHarvestTool appears like it will be a structural change to resolve and will have effects with downstream modules.
- Various rendering helpers.