### PR TITLE
Fixed UI ToolTip Rendering Behind Items Rendered in Gui's

### DIFF
--- a/src/main/java/mcjty/lib/gui/GenericGuiContainer.java
+++ b/src/main/java/mcjty/lib/gui/GenericGuiContainer.java
@@ -126,6 +126,7 @@ public abstract class GenericGuiContainer<T extends GenericTileEntity, C extends
     public void drawHoveringText(GuiGraphics graphics, List<String> textLines, List<ItemStack> items, int x, int y, Font font) {
         if (!textLines.isEmpty()) {
             PoseStack matrixStack = graphics.pose();
+            matrixStack.translate(0.0D, 0.0D, 400.0f);
             matrixStack.pushPose();
             // @todo 1.17 RenderSystem.disableRescaleNormal();
             // @todo 1.17 com.mojang.blaze3d.platform.Lighting.turnOff();
@@ -200,7 +201,7 @@ public abstract class GenericGuiContainer<T extends GenericTileEntity, C extends
             graphics.fillGradient(xx - 3, yy + k + 2, xx + i + 3, yy + k + 3, j1, j1);
 
 //            matrixStack.translate(0.0D, 0.0D, this.itemRenderer.blitOffset);
-            matrixStack.translate(0.0D, 0.0D, 300.0f);
+            matrixStack.translate(0.0D, 0.0D, 100.0f);
 
             renderTextLines(graphics, textLines, items, font, xx, yy);
 


### PR DESCRIPTION
Added an offset to the Matrix Stack so that the Tool Tip and Tool Tip background are pushed forward and renders in front of Items, 

Reduced the Translate offset for the Tool Tip text from 300 to 100, and added a 400 offset to the background and text.

Seems to work alright, not sure if this interferes with anything else.